### PR TITLE
getCameraLocation matrix fix

### DIFF
--- a/trunk/src/cameraparameters.cpp
+++ b/trunk/src/cameraparameters.cpp
@@ -98,7 +98,7 @@ cv::Point3f CameraParameters::getCameraLocation(cv::Mat Rvec,cv::Mat Tvec)
 
     //now, add translation information
     for (int i=0;i<3;i++)
-        m44.at<float>(i,3)=Tvec.at<float>(0,i);
+        m44.at<float>(i,3)=Tvec.at<float>(i,0);
     //invert the matrix
     m44.inv();
     return  cv::Point3f( m44.at<float>(0,0),m44.at<float>(0,1),m44.at<float>(0,2));


### PR DESCRIPTION
On android getCameraLocation is crashing, changing this line fixes the problem, and as far as i can see it works. On mac both variants returned the same value.